### PR TITLE
Add hardcoded ubuntu version to avoid failure in check_registry

### DIFF
--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -14,7 +14,9 @@ permissions:
 jobs:
   check-registry:
     name: Check registry entries
-    runs-on: 'ubuntu-latest'
+    # Temporary change for failure https://github.com/devfile/alizer/actions/runs/6230640715/job/16920449943
+    # For more info take a look at: https://github.com/actions/runner-images/issues/6709
+    runs-on: 'ubuntu-20.04'
     outputs:
       matrix: ${{ steps.get-stacks.outputs.matrix }}
     steps:


### PR DESCRIPTION
## What does this PR do?

Adds hardcoded value to `runs-on` field (e.g `ubuntu-20.04`) in order not to have cancellation failure. Seems like the case https://github.com/actions/runner-images/issues/6709

More details about the workflow failure can be found here: https://github.com/devfile/alizer/actions/runs/6230640715/job/16920449943

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1248

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
